### PR TITLE
ci: gate release tagging on CI/audit passing

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,11 +87,28 @@ For **each** published Python package, before tagging:
 
 ## Release
 
-7. **Tag.** `scripts/release-stack.sh --name vX.Y.Z --tag --push --apply`
+7. **Confirm release-readiness (CI/audit).** `publish.yml` triggers
+   directly on `push: tags: ["v*"]` and cannot `needs:` a job defined in
+   `ci.yml` or `audit.yml` (GitHub Actions has no cross-workflow
+   `needs:`), so this has to be checked before the tag exists.
+   `scripts/release-stack.sh --tag --apply` runs
+   `scripts/check-release-ready.sh` automatically before it creates or
+   pushes the tag, and refuses to tag if CI or the audit workflow hasn't
+   run, is still in progress, or didn't succeed on the target commit. If
+   tagging by hand instead, run the same check yourself first:
+
+   ```sh
+   scripts/check-release-ready.sh [ref]   # defaults to HEAD
+   ```
+
+   The check is bypassable with `release-stack.sh ... --skip-release-check`
+   for exceptional cases; there's no equivalent bypass for a by-hand tag
+   other than skipping the script entirely.
+8. **Tag.** `scripts/release-stack.sh --name vX.Y.Z --tag --push --apply`
    (or tag `vX.Y.Z` by hand). `publish.yml` triggers on `v*` and runs:
    crate publish (`continue-on-error`), openmassspec-io wheels + sdist +
    publish, and the openmassspec metapackage build + publish.
-8. **Watch the run.** A transient wheel-leg failure will skip
+9. **Watch the run.** A transient wheel-leg failure will skip
    `publish-openmassspec-io` (it `needs: [build-wheels, build-sdist]`). This
    is almost always a runner network flake, not a real error. Fix:
 
@@ -106,7 +123,7 @@ For **each** published Python package, before tagging:
 
 ## Post-release
 
-9. **Verify on PyPI.** For each package, confirm the new version has an
+10. **Verify on PyPI.** For each package, confirm the new version has an
    sdist and that the sdist contains `LICENSE`:
 
    ```sh
@@ -122,12 +139,12 @@ For **each** published Python package, before tagging:
    PY
    ```
 
-10. **Update `versions.toml`** in the ops repo and commit
+11. **Update `versions.toml`** in the ops repo and commit
     (`versions: bump OpenMassSpec to X.Y.Z`).
 
 ## conda-forge (two-stage)
 
-11. The facade's recipe depends on the binding, so submit in order:
+12. The facade's recipe depends on the binding, so submit in order:
     - First `openmassspec-io` to `conda-forge/staged-recipes`. Wait for the
       feedstock to be created and the package to appear on the channel.
     - Then `openmassspec` (a `noarch: python` recipe whose `run` requirement

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -23,7 +23,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 REF="${1:-HEAD}"
-SHA="$(git -C "$REPO_DIR" rev-parse "$REF")"
+# `^{commit}` peels annotated tags to the commit they point at; git rev-parse
+# on an annotated tag alone returns the tag object's own SHA, which never
+# matches a workflow run's head SHA.
+SHA="$(git -C "$REPO_DIR" rev-parse "${REF}^{commit}")"
 
 # Query the most recent run of a workflow for $SHA and judge it. Prints
 # a one-line status to stderr; returns non-zero unless the run exists,

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check-release-ready.sh - refuse to call a commit release-ready unless
+# CI and the security audit have both completed successfully for it.
+#
+# publish.yml triggers directly on `push: tags: ["v*"]`. GitHub Actions
+# has no way for one workflow file to `needs:` a job defined in another
+# workflow file, so publish.yml itself cannot be made to wait on ci.yml
+# or audit.yml. The gate has to live here, before the tag exists.
+#
+# scripts/release-stack.sh --apply runs this automatically before it
+# creates/pushes the umbrella tag. Run it by hand first when tagging
+# manually (see RELEASING.md step 7).
+#
+# Usage:
+#   scripts/check-release-ready.sh [ref]   # default ref: HEAD
+#
+# Exit codes:
+#   0 CI and audit both completed successfully for the resolved SHA
+#   1 CI or audit missing, not completed, or not successful for the SHA
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REF="${1:-HEAD}"
+SHA="$(git -C "$REPO_DIR" rev-parse "$REF")"
+
+# Query the most recent run of a workflow for $SHA and judge it. Prints
+# a one-line status to stderr; returns non-zero unless the run exists,
+# is completed, and succeeded.
+check_workflow() {
+    local workflow="$1"
+    local run_json status conclusion url
+
+    run_json="$(cd "$REPO_DIR" && gh run list -w "$workflow" -c "$SHA" \
+        --json status,conclusion,url -L 1)"
+
+    if [ "$run_json" = "[]" ]; then
+        echo "[error] no run of $workflow found for $SHA" >&2
+        return 1
+    fi
+
+    status="$(printf '%s' "$run_json" | jq -r '.[0].status')"
+    conclusion="$(printf '%s' "$run_json" | jq -r '.[0].conclusion')"
+    url="$(printf '%s' "$run_json" | jq -r '.[0].url')"
+
+    if [ "$status" != "completed" ]; then
+        echo "[error] $workflow for $SHA is not completed (status: $status) - $url" >&2
+        return 1
+    fi
+    if [ "$conclusion" != "success" ]; then
+        echo "[error] $workflow for $SHA did not succeed (conclusion: $conclusion) - $url" >&2
+        return 1
+    fi
+
+    echo "[ok] $workflow green for $SHA - $url" >&2
+    return 0
+}
+
+ready=1
+check_workflow ci.yml || ready=0
+check_workflow audit.yml || ready=0
+
+if [ "$ready" -ne 1 ]; then
+    echo "[error] $SHA is not release-ready" >&2
+    exit 1
+fi
+
+echo "[ok] $SHA is release-ready: CI and audit are both green" >&2
+exit 0

--- a/scripts/release-stack.sh
+++ b/scripts/release-stack.sh
@@ -26,6 +26,9 @@
 #                       only the gate command is reported.
 #   --gate-with-corpus  Pass --with-corpus to the SpecLance gate. Implies
 #                       --gate-speclance.
+#   --skip-release-check  Bypass the CI/audit release-readiness check
+#                       (scripts/check-release-ready.sh) that otherwise
+#                       runs automatically before tagging under --apply.
 #   --help              Show this help.
 #
 # Exit codes:
@@ -34,6 +37,8 @@
 #   2 dirty working tree in one of the repos
 #   3 missing sibling repo
 #   4 SpecLance truth-test gate failed (under --gate-speclance --apply)
+#   5 release-readiness check failed (CI/audit not green; under --apply,
+#     unless --skip-release-check)
 set -euo pipefail
 
 # Locations - this script lives in OpenMassSpec/scripts/.
@@ -81,6 +86,7 @@ DO_APPLY=0
 WRITE_STACK_MD=0
 DO_GATE=0
 GATE_WITH_CORPUS=0
+SKIP_RELEASE_CHECK=0
 
 usage() {
     sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
@@ -95,6 +101,7 @@ while [ $# -gt 0 ]; do
         --write-stack-md) WRITE_STACK_MD=1; shift ;;
         --gate-speclance) DO_GATE=1; shift ;;
         --gate-with-corpus) DO_GATE=1; GATE_WITH_CORPUS=1; shift ;;
+        --skip-release-check) SKIP_RELEASE_CHECK=1; shift ;;
         --help|-h) usage; exit 0 ;;
         *) echo "Unknown flag: $1" >&2; usage >&2; exit 1 ;;
     esac
@@ -231,6 +238,26 @@ if [ "$DO_GATE" -eq 1 ]; then
         echo "[ok] SpecLance truth-test gate green" >&2
     else
         echo "[dry-run] would run gate: ${gate_cmd[*]}" >&2
+    fi
+fi
+
+# Refuse to tag a commit unless CI and audit are both green for it.
+# publish.yml cannot `needs:` a job in a separate workflow file, so this
+# is enforced here, before the tag exists, rather than inside
+# publish.yml. Runs automatically under --apply; --skip-release-check
+# bypasses it for exceptional cases.
+if [ "$DO_TAG" -eq 1 ]; then
+    if [ "$SKIP_RELEASE_CHECK" -eq 1 ]; then
+        echo "[warn] skipping release-readiness check (--skip-release-check)" >&2
+    elif [ "$DO_APPLY" -eq 1 ]; then
+        echo "[check] running: $SCRIPT_DIR/check-release-ready.sh" >&2
+        if ! "$SCRIPT_DIR/check-release-ready.sh" >&2; then
+            echo "[error] release-readiness check failed; refusing to tag" >&2
+            exit 5
+        fi
+        echo "[ok] release-readiness check passed" >&2
+    else
+        echo "[dry-run] would run: $SCRIPT_DIR/check-release-ready.sh" >&2
     fi
 fi
 


### PR DESCRIPTION
## Summary

- `publish.yml` triggers directly on `push: tags: ["v*"]`, with no dependency on `ci.yml` or `audit.yml` passing. GitHub Actions has no way for one workflow file to `needs:` a job defined in a separate workflow file, so the gate has to be enforced before the tag exists, not inside `publish.yml`.
- Adds `scripts/check-release-ready.sh`: resolves a git ref (default `HEAD`) to a SHA, then checks the most recent run of `ci.yml` and `audit.yml` for that exact commit via `gh run list -w <workflow> -c <sha> --json status,conclusion,url -L 1`. Prints a clear message (with run URL when available) and exits 1 if either workflow has no run, isn't `completed`, or didn't `conclusion: success`; exits 0 with a one-line confirmation if both are green.
- Wires the check into `scripts/release-stack.sh`: it now runs automatically before `--tag --apply` creates/pushes the umbrella tag (new exit code 5 on failure), placed alongside the existing `--gate-speclance` gate and following the same conventions. Bypassable with a new `--skip-release-check` flag for exceptional cases, mirroring the escape-hatch style already used elsewhere in the script.
- Adds a new numbered step 7 to `RELEASING.md`'s Release section documenting that `release-stack.sh --apply` runs this automatically, and how to run `scripts/check-release-ready.sh` by hand when tagging manually. Subsequent steps renumbered (Tag=8 ... conda-forge=12).

## Testing

Ran `scripts/check-release-ready.sh` standalone against several commits on `main`:
- Current `main` HEAD (a docs-only commit): `ci.yml` reports green, but `audit.yml` correctly reports no run for that exact SHA (it's path-filtered to `Cargo.toml`/`Cargo.lock`/`audit.yml` changes and this commit touched none of those) - script correctly exits 1. This is expected behavior per the literal per-commit check the issue asked for, not a bug, but worth flagging: audit's path-filtered trigger means most non-dependency-touching commits won't have a same-SHA audit run.
- The `v1.5.0` release commit (`24a8949`), which did touch dependency-adjacent files earlier in its chain: both `ci.yml` and `audit.yml` report green for the exact SHA - script correctly exits 0.
- A commit that touched `Cargo.toml` (`278e078`): both green, exits 0.
- A bad ref: fails loudly via `git rev-parse`'s own error (script uses `set -euo pipefail`, no swallowed failure).

Also verified the `release-stack.sh` wiring itself. The full script can't run end-to-end from a git worktree checkout (its dirty-tree check expects `.git` to be a directory, which doesn't hold for worktrees - pre-existing, unrelated to this change), so I exercised the new gate block directly with each `DO_TAG`/`DO_APPLY`/`SKIP_RELEASE_CHECK` combination:
- `--tag` (no `--apply`): dry-run message only, reaches past the gate without invoking the real check.
- `--tag --apply`: invokes `check-release-ready.sh` for real, correctly propagates its failure as exit 5 and refuses to tag.
- `--tag --apply --skip-release-check`: prints a warning and skips the check entirely.

`bash -n` passes on both scripts; `--help` output renders the new flag/exit-code docs correctly.

Closes #7