### PR TITLE
security: bump mzdata 0.63.5 -> 0.65.4, clearing quick-xml RUSTSEC-2026-0194/0195

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,12 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-audit
-      # quick-xml (RUSTSEC-2026-0194/0195) is a transitive dep via mzdata.
-      # mobiusklein/mzdata#53 bumped it to 0.41 on mzdata's main branch
-      # (merged 2026-07-14) but mzdata hasn't cut a release since - still
-      # nothing to bump here until it does. Tracked in
-      # Sigilweaver/OpenMassSpec#4.
-      - run: >
-          cargo audit
-          --ignore RUSTSEC-2026-0194
-          --ignore RUSTSEC-2026-0195
+      # quick-xml (RUSTSEC-2026-0194/0195) was a transitive dep via mzdata,
+      # pinned to quick-xml "^0.30". mobiusklein/mzdata#53 bumped it to
+      # 0.41 on mzdata's main branch (merged 2026-07-14) and shipped in
+      # mzdata 0.65.4 (published 2026-07-14). Cleared by bumping mzdata to
+      # 0.65.4 here; see Sigilweaver/OpenMassSpec#4.
+      - run: cargo audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- Bumped `mzdata` from 0.63.5 to 0.65.4 in `openmassspec-io-cli`, pulling
+  in `mzdata`'s own quick-xml 0.30 -> 0.41 upgrade
+  ([mobiusklein/mzdata#53](https://github.com/mobiusklein/mzdata/pull/53))
+  and clearing RUSTSEC-2026-0194/0195. No API changes needed on our side;
+  `mzml_reader.rs`'s usage of `MzMLReader`/`RawSpectrum`/`prelude` traits
+  is unaffected by the intervening 0.64.x/0.65.x releases. The `cargo
+  audit` CI job no longer needs to `--ignore` either advisory. Closes #4.
+
 ## [1.5.0] - 2026-07-18
 
 ### Added

--- a/crates/openmassspec-io-cli/Cargo.toml
+++ b/crates/openmassspec-io-cli/Cargo.toml
@@ -17,7 +17,7 @@ openmassspec-core = { workspace = true }
 openmassspec-io = { path = "../openmassspec-io", features = ["all"] }
 clap = { version = "4.5", features = ["derive"] }
 flate2 = "1.0"
-mzdata = { version = "0.63.5", default-features = false, features = ["mzml"] }
+mzdata = { version = "0.65.4", default-features = false, features = ["mzml"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Bumps `mzdata` from 0.63.5 to 0.65.4 in `crates/openmassspec-io-cli/Cargo.toml`. mzdata 0.65.4 (published 2026-07-14) upgraded its own `quick-xml` dependency from `^0.30` to `^0.41` (mobiusklein/mzdata#53, merged 2026-07-14), which is what actually clears RUSTSEC-2026-0194/0195 - they were only reachable transitively via mzdata's old pin.
- Reviewed mzdata's CHANGELOG for every version between 0.63.5 and 0.65.4 (0.64.0, 0.64.1, 0.65.0, 0.65.1, 0.65.2, 0.65.3, 0.65.4). Nothing in that range touches the `MzMLReader`/`RawSpectrum`/prelude-trait API surface `crates/openmassspec-io-cli/src/mzml_reader.rs` consumes (`id()`, `ms_level()`, `start_time()`, `polarity()`, `mzs()`, `intensities()`, `precursor()`, `index()`). No source changes were needed.
- `cargo test --workspace --all-features` passes, including the `cli_validate`/`cli_centroid` integration tests that exercise `mzml_reader.rs` against real mzML output.
- `cargo audit` now reports zero advisories locally. Removed both `--ignore RUSTSEC-2026-0194`/`--ignore RUSTSEC-2026-0195` flags from `audit.yml` and updated its now-stale explanatory comment.
- Added a CHANGELOG entry under `[Unreleased]`.

This does not touch pyo3 (already bumped to 0.29 in a prior commit, ca8bb56) or any Python-side CI changes.

Closes #4

## Test plan
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features` (all green)
- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-features --all-targets -- -D warnings` (clean)
- [x] `cargo audit` locally (zero advisories)
- [ ] CI green (rust/msrv/python/audit jobs)