### PR TITLE
Fix stale vendor list and repo-count comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `vendor2mzml`'s unrecognized-format error message and the `convert`
+  subcommand's `input` help text now list all six supported vendors
+  (Agilent, SCIEX, and Shimadzu were missing from both). `scripts/
+  release-stack.sh`'s header comment now describes the current
+  eight-repo stack instead of the stale five-repo one from before
+  OpenARaw/OpenSXRaw/OpenSZRaw landed. Text-only change, no behavior
+  change. Fix contributed by @Nabejo. Closes #18.
+
 ## [1.5.2] - 2026-07-20
 
 ### Security

--- a/crates/openmassspec-io-cli/src/main.rs
+++ b/crates/openmassspec-io-cli/src/main.rs
@@ -47,8 +47,9 @@ enum Cmd {
 
 #[derive(Args, Debug)]
 struct ConvertArgs {
-    /// Input path: a `.raw` file (Thermo) or a `.d/` / `.raw/` bundle
-    /// directory (Bruker, Waters).
+    /// Input path: a `.raw` file (Thermo), a `.wiff` file (SCIEX), a
+    /// `.qgd` / `.lcd` file (Shimadzu), or a `.d/` / `.raw/` bundle
+    /// directory (Bruker, Agilent, Waters).
     input: PathBuf,
     /// Output mzML path. Use a `.mzML.gz` extension to write gzipped
     /// output (auto-detected from the file name).
@@ -128,7 +129,9 @@ fn run_convert(args: ConvertArgs) -> ExitCode {
             "error: {} does not look like a supported vendor format",
             args.input.display()
         );
-        eprintln!("  (recognized: Thermo .raw, Bruker .d/, Waters .raw/)");
+        eprintln!(
+            "  (recognized: Thermo .raw, Bruker .d/, Waters .raw/, Agilent .d/, SCIEX .wiff, Shimadzu .qgd/.lcd)"
+        );
         return ExitCode::from(1);
     };
     eprintln!(

--- a/scripts/release-stack.sh
+++ b/scripts/release-stack.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # release-stack.sh - coordinated stack release helper for OpenMassSpec.
 #
-# Reads pinned versions across the five-repo stack (this repo +
-# OpenMassSpecCore, OpenTFRaw, OpenTimsTDF, OpenWRaw), emits a release-notes
-# draft aggregated from each repo's CHANGELOG.md, and optionally creates
-# and pushes an annotated umbrella SemVer tag on this repo.
+# Reads pinned versions across the eight-repo stack (this repo +
+# OpenMassSpecCore, OpenTFRaw, OpenTimsTDF, OpenWRaw, OpenARaw, OpenSXRaw,
+# OpenSZRaw), emits a release-notes draft aggregated from each repo's
+# CHANGELOG.md, and optionally creates and pushes an annotated umbrella
+# SemVer tag on this repo.
 #
 # Usage:
 #   scripts/release-stack.sh                       # dry-run, notes to stdout


### PR DESCRIPTION
## Summary

`crates/openmassspec-io-cli/src/main.rs`'s `run_convert` error message and `ConvertArgs.input` doc comment only listed 3 of the 6 supported vendors (Thermo, Bruker, Waters), omitting Agilent, SCIEX, and Shimadzu even though `detect_format` has supported all six since v1.5.0. `scripts/release-stack.sh`'s header comment also described a stale "five-repo stack" while its actual `REPOS` array has listed all 8 repos (including OpenARaw, OpenSXRaw, OpenSZRaw) for a while.

Updates both doc comment and error message in `main.rs` to list all six vendors with their correct on-disk shapes (cross-checked against the actual `detect_format`/`is_sciex_wiff`/`is_shimadzu_labsolutions` logic in `crates/openmassspec-io/src/lib.rs`), and updates `release-stack.sh`'s header comment to match its `REPOS` array. Text-only change, no behavior change.

Closes #18.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (31 tests, all passing)

Contributed by @Nabejo.