### PR TITLE
Delegate Python format detection to the Rust detect_format binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Python's `openmassspec.detect()`/`open_run()` now delegate to the
+  Rust `openmassspec_io.detect_format` binding instead of
+  reimplementing the vendor structural checks by hand. The two
+  implementations had drifted: the Python side never checked
+  Shimadzu's CFBF/OLE2 magic bytes the way `detect_format` does (so a
+  renamed/garbage `.qgd`/`.lcd` file was wrongly reported as
+  Shimadzu), and it matched a wider, undocumented set of Waters
+  sentinel files (`_FUNCTNS.INF`, `_extern.inf`, `_HEADER.TXT`) than
+  the canonical `_HEADER.TXT`-only check. There is now a single source
+  of truth for format detection. Fixed by @Nabejo. Closes #19.
+
 ## [1.5.2] - 2026-07-20
 
 ### Security

--- a/python/openmassspec/__init__.py
+++ b/python/openmassspec/__init__.py
@@ -30,8 +30,10 @@ Top-level helpers fall into two layers:
 
 * ``detect_format``, ``to_mzml``, ``iter_spectra`` are re-exports from
   ``openmassspec_io`` - the vendor-agnostic reader.
-* ``detect``, ``open_run`` use only structural checks and dispatch to
-  the vendor extension that matches the input path (requires the
+* ``detect``, ``open_run`` delegate to ``detect_format`` (there is a
+  single, canonical implementation of the structural checks, in
+  ``openmassspec-io``'s Rust ``detect_format``) and dispatch to the
+  vendor extension that matches the input path (requires the
   corresponding extra).
 """
 
@@ -81,37 +83,28 @@ def detect(path: str | os.PathLike[str]) -> Optional[str]:
     """Return ``"thermo"``, ``"bruker"``, ``"waters"``, ``"agilent"``,
     ``"sciex"``, ``"shimadzu"`` or ``None`` for *path*.
 
-    The check is purely structural (extension + sentinel files); no vendor
-    reader needs to be importable.
+    Delegates to :func:`detect_format` (the ``openmassspec_io`` Rust
+    binding), which is the single, canonical implementation of every
+    vendor's structural signature - extension and/or sentinel files,
+    plus, where applicable, content checks such as Shimadzu's CFBF/OLE2
+    magic bytes or Thermo's "Finnigan" marker. This function used to
+    reimplement those checks by hand and had drifted from the Rust
+    side (it never verified Shimadzu's magic bytes the way the Rust
+    side does, and matched a wider, undocumented set of Waters sentinel
+    files than the canonical ``_HEADER.TXT`` check); it now forwards to
+    ``detect_format`` so there is one source of truth. See
+    ``crates/openmassspec-io/src/lib.rs``'s ``detect_format`` (and
+    ``docs/docs/format-detection.md``) for the exact per-vendor rules.
+
+    The check is purely structural; no vendor reader needs to be
+    importable.
     """
-    p = Path(path)
-    if not p.exists():
-        return None
-    if p.is_file():
-        if p.suffix.lower() == ".raw":
-            return "thermo"
-        # SCIEX: a .wiff file with its paired .wiff.scan alongside.
-        if p.suffix.lower() == ".wiff" and Path(str(p) + ".scan").is_file():
-            return "sciex"
-        # Shimadzu: self-contained, no sibling file to check - extension
-        # alone (matches this function's existing "purely structural"
-        # precedent; the Rust-side detect_format additionally verifies
-        # the CFBF/OLE2 magic bytes, see openmassspec-io's detect_format).
-        if p.suffix.lower() in (".qgd", ".lcd"):
-            return "shimadzu"
-    if p.is_dir():
-        suffix = p.suffix.lower()
-        # Bruker and Agilent both use a .d directory; disambiguate by contents.
-        if suffix == ".d" and (p / "analysis.tdf").is_file():
-            return "bruker"
-        if (p / "AcqData" / "MSScan.bin").is_file():
-            return "agilent"
-        if suffix == ".raw" and any(
-            (p / name).exists()
-            for name in ("_FUNCTNS.INF", "_extern.inf", "_HEADER.TXT")
-        ):
-            return "waters"
-    return None
+    if detect_format is None:
+        raise ImportError(
+            "openmassspec_io is required for detect(); it is a hard "
+            "dependency of the openmassspec base install"
+        )
+    return detect_format(Path(path))
 
 
 def open_run(path: str | os.PathLike[str]):

--- a/python/tests/test_metapackage.py
+++ b/python/tests/test_metapackage.py
@@ -15,6 +15,35 @@ from pathlib import Path
 import openmassspec
 import pytest
 
+# `detect()` forwards to `openmassspec_io.detect_format`, which - like the
+# Rust `detect_format` it binds - verifies content, not just extension, for
+# Thermo and Shimadzu. These are the exact byte sequences
+# `crates/openmassspec-io/src/lib.rs`'s `is_thermo_raw`/
+# `is_shimadzu_labsolutions` check for; see `docs/docs/format-detection.md`.
+FINNIGAN_HEADER = bytes(
+    [
+        0x01,
+        0xA1,
+        0x46,
+        0x00,
+        0x69,
+        0x00,
+        0x6E,
+        0x00,
+        0x6E,
+        0x00,
+        0x69,
+        0x00,
+        0x67,
+        0x00,
+        0x61,
+        0x00,
+        0x6E,
+        0x00,
+    ]
+)
+CFBF_MAGIC = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1])
+
 
 def test_version_string():
     assert isinstance(openmassspec.__version__, str)
@@ -34,14 +63,27 @@ def test_vendors_tuple():
 
 def test_detect_thermo_file(tmp_path: Path):
     f = tmp_path / "sample.raw"
-    f.write_bytes(b"")
+    f.write_bytes(FINNIGAN_HEADER)
     assert openmassspec.detect(f) == "thermo"
+
+
+def test_detect_thermo_file_without_finnigan_magic_is_none(tmp_path: Path):
+    """A bare `.raw` extension is not enough - content must match too.
+
+    Regression test for the bug in #19: the old hand-rolled `detect()`
+    trusted the `.raw` extension alone and never checked the Finnigan
+    magic bytes the way the canonical Rust `detect_format` does.
+    """
+    f = tmp_path / "sample.raw"
+    f.write_bytes(b"not actually a thermo file")
+    assert openmassspec.detect(f) is None
 
 
 def test_detect_bruker_d(tmp_path: Path):
     d = tmp_path / "sample.d"
     d.mkdir()
     (d / "analysis.tdf").write_bytes(b"")
+    (d / "analysis.tdf_bin").write_bytes(b"")
     assert openmassspec.detect(d) == "bruker"
 
 
@@ -69,14 +111,28 @@ def test_detect_sciex_wiff(tmp_path: Path):
 
 def test_detect_shimadzu_lcd(tmp_path: Path):
     f = tmp_path / "sample.lcd"
-    f.write_bytes(b"")
+    f.write_bytes(CFBF_MAGIC)
     assert openmassspec.detect(f) == "shimadzu"
 
 
 def test_detect_shimadzu_qgd(tmp_path: Path):
     f = tmp_path / "sample.qgd"
-    f.write_bytes(b"")
+    f.write_bytes(CFBF_MAGIC)
     assert openmassspec.detect(f) == "shimadzu"
+
+
+def test_detect_shimadzu_lcd_without_cfbf_magic_is_none(tmp_path: Path):
+    """A bare `.lcd`/`.qgd` extension is not enough - content must match too.
+
+    Regression test for the bug in #19: the old hand-rolled `detect()`
+    trusted the extension alone for Shimadzu and never checked the
+    CFBF/OLE2 magic bytes the way the canonical Rust `detect_format`
+    does - so it would have wrongly called a renamed/garbage file
+    Shimadzu.
+    """
+    f = tmp_path / "sample.lcd"
+    f.write_bytes(b"not a real container")
+    assert openmassspec.detect(f) is None
 
 
 def test_detect_wiff_without_scan_is_none(tmp_path: Path):
@@ -130,7 +186,7 @@ def test_open_run_thermo_dispatch(monkeypatch, tmp_path: Path):
     import types
 
     f = tmp_path / "sample.raw"
-    f.write_bytes(b"")
+    f.write_bytes(FINNIGAN_HEADER)
     calls: list[str] = []
 
     fake = types.ModuleType("opentfraw")
@@ -148,6 +204,7 @@ def test_open_run_bruker_dispatch(monkeypatch, tmp_path: Path):
     d = tmp_path / "sample.d"
     d.mkdir()
     (d / "analysis.tdf").write_bytes(b"")
+    (d / "analysis.tdf_bin").write_bytes(b"")
     calls: list[str] = []
 
     fake = types.ModuleType("opentimstdf")
@@ -217,7 +274,7 @@ def test_open_run_shimadzu_dispatch(monkeypatch, tmp_path: Path):
     import types
 
     f = tmp_path / "sample.lcd"
-    f.write_bytes(b"")
+    f.write_bytes(CFBF_MAGIC)
     calls: list[str] = []
 
     fake = types.ModuleType("openszraw")


### PR DESCRIPTION
## Summary

Format detection was duplicated between the Rust `openmassspec_io::detect_format` (the canonical structural-detection implementation) and a hand-rolled Python `detect()` in `python/openmassspec/__init__.py`, and had drifted: Python never verified Shimadzu's CFBF/OLE2 magic bytes, and accepted a wider, undocumented set of Waters sentinel files (`_FUNCTNS.INF`, `_extern.inf`, `_HEADER.TXT`) instead of the documented `_HEADER.TXT`-only check.

`detect()` now forwards directly to `detect_format` (the already-imported re-export of the Rust `openmassspec_io.detect` binding) instead of reimplementing the logic; `open_run()` needed no change since it just calls `detect()`. Updated `python/tests/test_metapackage.py` fixtures that relied on the old, looser behavior (Thermo/Shimadzu fixtures now write real magic bytes; Bruker fixtures now also write `analysis.tdf_bin` since `detect_format` requires both files), and added two regression tests exercising the exact drift described in the issue.

Closes #19.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (31 tests, all passing)
- [x] Built the real PyO3 extension (`maturin develop --release --features pyo3/extension-module`) and ran `pytest python/tests -v`: 25 passed
- [x] `pytest crates/openmassspec-io-py/tests`: 2 passed, 18 skipped (vendor-corpus-gated, same as CI without corpus secrets)

Contributed by @Nabejo.