### PR TITLE
fix: bump openmassspec-core floor to 1.4.0 and update test fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Adapted the `cli_validate` test fixture's `RunMetadata` literal to
+  `openmassspec-core` 1.4.0's new `acquisition_software_name`/
+  `acquisition_software_version` fields (`None, None` - synthetic
+  fixture, no real vendor data to source a value from). Bumped the
+  stale `openmassspec-core = "1.2.0"` workspace floor to `"1.4.0"`, and
+  the six vendor-crate floors (`opentfraw`, `opentimstdf`, `openwraw`,
+  `openaraw`, `opensxraw`, `openszraw`) to the releases that actually
+  compile against it, now that all six have published their own
+  core-1.4.0 adaptations. (Sigilweaver/OpenMassSpec#22)
 - Bumped the workspace `rust-version` (and the MSRV CI job) from 1.88 to
   1.95. `opentimstdf`'s `rusqlite ^0.40` dependency (pulled in only by
   the optional `bruker`/`all` feature) now resolves to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ homepage = "https://sigilweaver.app/openmassspec/"
 documentation = "https://sigilweaver.app/openmassspec/docs/"
 
 [workspace.dependencies]
-openmassspec-core = "1.2.0"
-opentfraw = "1.3.5"
-opentimstdf = "1.3.0"
-openwraw = "1.2.6"
-openaraw = "0.1.3"
-opensxraw = "0.2.2"
-openszraw = "0.1.1"
+openmassspec-core = "1.4.0"
+opentfraw = "1.3.7"
+opentimstdf = "1.3.2"
+openwraw = "1.2.8"
+openaraw = "0.1.6"
+opensxraw = "0.2.4"
+openszraw = "0.1.3"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/openmassspec-io-cli/tests/cli_validate.rs
+++ b/crates/openmassspec-io-cli/tests/cli_validate.rs
@@ -31,6 +31,8 @@ fn make_metadata() -> RunMetadata {
         start_timestamp: None,
         mobility_array_kind: None,
         analyzers: Vec::new(),
+        acquisition_software_name: None,
+        acquisition_software_version: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Adapts the `cli_validate` test fixture's `RunMetadata` literal to openmassspec-core 1.4.0's new `acquisition_software_name`/`acquisition_software_version` fields (`None, None` - synthetic fixture, no real data source).
- Bumps the stale `openmassspec-core = "1.2.0"` workspace floor to `"1.4.0"`.
- Bumps the six vendor-crate floors (`opentfraw`, `opentimstdf`, `openwraw`, `openaraw`, `opensxraw`, `openszraw`) to the releases that actually compile against core 1.4.0, now that all six have published their own adaptations (OpenARaw 0.1.6, OpenSXRaw 0.2.4, OpenSZRaw 0.1.3, OpenTFRaw 1.3.7, OpenTimsTDF 1.3.2, OpenWRaw 1.2.8).

This was previously blocked: `openmassspec-io-cli`/`-py` pull in all six vendor crates unconditionally via the `all` feature, so Cargo unifies the whole graph onto whatever `openmassspec-core` version resolves - once 1.4.0 was resolvable, the six vendor crates' *published* crates.io releases (pre-adaptation) broke the build even though this repo's own code doesn't construct `RunMetadata` directly. Now that all six have released their fixes, `cargo update` resolves everyone to compatible versions and the workspace builds clean.

## Testing

- `cargo fmt --all -- --check` - clean.
- `cargo clippy --all-targets -- -D warnings` - clean, zero warnings.
- `cargo test --all` - all tests pass.
- `pytest python/tests` (after `maturin develop --release` rebuild) - 25 passed.

Closes #22