### PR TITLE
test: add Agilent/SCIEX coverage to vendor2mzml.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,22 +63,24 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
-      # Populates repo-root corpus/ with the six small vendor fixtures
+      # Populates repo-root corpus/ with the eight small vendor fixtures
       # crates/openmassspec-io/tests/vendor2mzml.rs and
       # crates/openmassspec-io-cli/tests/cli_centroid.rs look for, so
       # those tests exercise a real decode path here instead of always
-      # skipping - see Sigilweaver/OpenMassSpec#24. Combined the six
-      # fixtures are ~140 MB (dominated by the ~90 MB Bruker bundle), so
-      # (matching the existing OS-independent-checks convention above,
-      # and precedent in OpenTimsTDF's own CI for the same Bruker
-      # fixture) this only runs on the ubuntu-latest leg; macOS/Windows
-      # continue to skip these six tests as they do today.
+      # skipping - see Sigilweaver/OpenMassSpec#24 (Thermo/Waters/Bruker/
+      # Shimadzu) and #25 (Agilent/SCIEX). Combined the fixtures are
+      # ~145 MB (dominated by the ~90 MB Bruker bundle), so (matching the
+      # existing OS-independent-checks convention above, and precedent in
+      # OpenTimsTDF's own CI for the same Bruker fixture) this only runs
+      # on the ubuntu-latest leg; macOS/Windows continue to skip these
+      # tests as they do today.
       - name: Download corpus fixtures for smoke tests
         if: matrix.os == 'ubuntu-latest'
         run: |
           set -e
           mkdir -p corpus/thermo corpus/waters corpus/bruker \
-            corpus/shimadzu/PXD034978 corpus/shimadzu/MTBLS432 corpus/shimadzu/MSV000084197
+            corpus/shimadzu/PXD034978 corpus/shimadzu/MTBLS432 corpus/shimadzu/MSV000084197 \
+            corpus/agilent corpus/sciex/PXD022088
 
           # Thermo (PXD068962, PRIDE, CC0)
           curl -sSL --user-agent "OpenMassSpec-CI/1.0" \
@@ -116,6 +118,25 @@ jobs:
           curl -sSL --user-agent "OpenMassSpec-CI/1.0" \
             -o corpus/shimadzu/MSV000084197/20190607_NM16.lcd \
             "https://massive.ucsd.edu/ProteoSAFe/DownloadResultFile?file=f.MSV000084197%2Fraw%2F20190607_NM16.lcd"
+
+          # Agilent QTOF (PXD030293, PRIDE, CC0) - zipped bundle directory,
+          # ~960 KB zipped; same fixture wired into OpenARaw's own CI, see
+          # Sigilweaver/OpenARaw#28.
+          curl -sSL --user-agent "OpenMassSpec-CI/1.0" -o agilent.d.zip \
+            "https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/07/PXD030293/180814-Sample19.d.zip"
+          unzip -q -d corpus/agilent agilent.d.zip
+          rm agilent.d.zip
+          test -d corpus/agilent/180814-Sample19.d
+
+          # SCIEX (PXD022088, PRIDE, CC0) - .wiff + .wiff.scan pair, ~2.5 MB
+          # total; same fixture wired into OpenSXRaw's own CI, see
+          # Sigilweaver/OpenSXRaw#33.
+          curl -sSL --user-agent "OpenMassSpec-CI/1.0" \
+            -o corpus/sciex/PXD022088/Rcor2KOESC1.wiff \
+            "https://ftp.pride.ebi.ac.uk/pride/data/archive/2020/12/PXD022088/Rcor2KOESC1.wiff"
+          curl -sSL --user-agent "OpenMassSpec-CI/1.0" \
+            -o corpus/sciex/PXD022088/Rcor2KOESC1.wiff.scan \
+            "https://ftp.pride.ebi.ac.uk/pride/data/archive/2020/12/PXD022088/Rcor2KOESC1.wiff.scan"
 
           du -sh corpus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added Agilent (`.d`, MassHunter) and SCIEX (`.wiff`) smoke/centroid/
+  stream-vs-collect test coverage to
+  `crates/openmassspec-io/tests/vendor2mzml.rs`, which previously only
+  exercised Thermo, Waters, Bruker, and Shimadzu even though both vendors
+  are already wired into `openmassspec-io` behind the `agilent`/`sciex`
+  feature flags. `.github/workflows/ci.yml`'s corpus-download step now
+  also fetches the small Agilent QTOF (PXD030293, ~960 KB zipped) and
+  SCIEX (PXD022088, ~2.5 MB `.wiff`+`.wiff.scan` pair) fixtures already
+  validated by OpenARaw#28 and OpenSXRaw#33 respectively, so these six
+  new tests run for real in CI rather than skipping. (Sigilweaver/OpenMassSpec#25)
+
 ### Changed
 
 - Wired real corpus fixtures into CI for `crates/openmassspec-io/tests/vendor2mzml.rs`

--- a/crates/openmassspec-io/tests/vendor2mzml.rs
+++ b/crates/openmassspec-io/tests/vendor2mzml.rs
@@ -78,6 +78,23 @@ fn shimadzu_lcd_qtof_fixture() -> PathBuf {
     ])
 }
 
+fn agilent_fixture() -> PathBuf {
+    first_existing(&[
+        manifest_dir().join("../../corpus/agilent/180814-Sample19.d"),
+        manifest_dir().join("../../../OpenARaw/corpus/PXD030293/180814-Sample19.d"),
+    ])
+}
+
+/// The SCIEX reader needs the sibling `.wiff.scan` file present next to
+/// the `.wiff` path returned here, not just the path itself - see the
+/// download step in ci.yml, which fetches both.
+fn sciex_fixture() -> PathBuf {
+    first_existing(&[
+        manifest_dir().join("../../corpus/sciex/PXD022088/Rcor2KOESC1.wiff"),
+        manifest_dir().join("../../../OpenSXRaw/corpus/PXD022088/Rcor2KOESC1.wiff"),
+    ])
+}
+
 /// Derive a filesystem-safe, per-input-file component for temp output
 /// names. Needed because several vendors (e.g. Shimadzu's three on-disk
 /// variants) share one `VendorFormat::name()`, so `name()` + pid alone
@@ -153,6 +170,16 @@ fn shimadzu_lcd_qtof_smoke() {
     smoke(shimadzu_lcd_qtof_fixture());
 }
 
+#[test]
+fn agilent_smoke() {
+    smoke(agilent_fixture());
+}
+
+#[test]
+fn sciex_smoke() {
+    smoke(sciex_fixture());
+}
+
 /// After `convert_to_mzml_centroided`, no spectrum in the output should
 /// still be tagged profile mode - every profile spectrum was centroided,
 /// and every already-centroid spectrum passed through unchanged. This
@@ -203,6 +230,16 @@ fn shimadzu_centroid_smoke() {
     // The QTOF variant is already centroid; MS1000127 should still be
     // present (pass-through), same invariant as the other vendors' tests.
     centroid_smoke(shimadzu_lcd_qtof_fixture());
+}
+
+#[test]
+fn agilent_centroid_smoke() {
+    centroid_smoke(agilent_fixture());
+}
+
+#[test]
+fn sciex_centroid_smoke() {
+    centroid_smoke(sciex_fixture());
 }
 
 /// `stream()`/`metadata_only()` must agree with `collect()` on both the
@@ -258,4 +295,14 @@ fn bruker_stream_matches_collect() {
 #[test]
 fn shimadzu_stream_matches_collect() {
     stream_matches_collect(shimadzu_qgd_fixture());
+}
+
+#[test]
+fn agilent_stream_matches_collect() {
+    stream_matches_collect(agilent_fixture());
+}
+
+#[test]
+fn sciex_stream_matches_collect() {
+    stream_matches_collect(sciex_fixture());
 }


### PR DESCRIPTION
## Summary

- `crates/openmassspec-io/tests/vendor2mzml.rs` previously only exercised Thermo, Waters, Bruker, and Shimadzu, even though Agilent (`.d`, MassHunter) and SCIEX (`.wiff`) are already wired into `openmassspec-io` behind the `agilent`/`sciex` feature flags. Adds `agilent_smoke`/`sciex_smoke` and their centroid/`stream_matches_collect` siblings, following the existing per-vendor pattern.
- `ci.yml`'s corpus-download step now also fetches the small Agilent QTOF (PXD030293/180814-Sample19.d.zip, ~960 KB zipped) and SCIEX (PXD022088/Rcor2KOESC1.wiff + .wiff.scan, ~2.5 MB total) fixtures already validated by OpenARaw#28 and OpenSXRaw#33 respectively.

Closes #25

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] Downloaded both new fixtures locally into `corpus/` and ran `cargo test --workspace --all-features`: all 20 `vendor2mzml` tests pass for real (not skipped), including the 6 new Agilent/SCIEX ones